### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -22,18 +22,30 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
   // Sanitizar URL da imagem para prevenir XSS
   const getSafeImageUrl = (url: string | undefined): string => {
     if (!url) return '';
-    
-    // Permitir URLs relativas seguras
+
+    // Permite apenas caminhos relativos estritos controlados pela aplicação
     if (url.startsWith('/uploads/') || url.startsWith('/assets/')) {
       return url;
     }
-    
-    // Permitir URLs do backend em produção
-    if (url.startsWith('https://santa-rita-backend.onrender.com/uploads/')) {
-      return url;
+
+    // Permite apenas URLs HTTPS do backend em produção, e restringe explicitamente o caminho
+    try {
+      const allowedOrigin = 'https://santa-rita-backend.onrender.com';
+      const allowedPathPrefix = '/uploads/';
+      // Se URL é absoluta, verifica origem e caminho
+      const parsedUrl = new URL(url, allowedOrigin); // permite paths relativos também
+      if (
+        parsedUrl.origin === allowedOrigin &&
+        parsedUrl.pathname.startsWith(allowedPathPrefix) &&
+        parsedUrl.protocol === 'https:'
+      ) {
+        return parsedUrl.href;
+      }
+    } catch (e) {
+      // URL constructor throws if url is invalid, fallback to blocking.
     }
-    
-    // Bloquear URLs externas não autorizadas
+
+    // Bloquear URLs externas, protocolos perigosos (javascript:, data:, blob:, etc.)
     return '';
   };
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
Potential fix for [https://github.com/mateusribeirocampos/santarita/security/code-scanning/8](https://github.com/mateusribeirocampos/santarita/security/code-scanning/8)

To fix the problem, make the `getSafeImageUrl` function *strictly validate* the URL passed to the `img` tag, leaving absolutely no room for XSS vectors or browser quirks. Prefer constructing an `URL` object (when full URLs are given) or performing a robust check on path-based relative URLs. Explicitly disallow potentially dangerous protocols such as `javascript:`, `data:`, and `blob:`, and allow only safe, application-controlled origins and path prefixes (as already attempted).

Implementation steps (in `frontend/src/components/ImageUpload.tsx`):  
- Replace the current string checks in `getSafeImageUrl` with logic that:  
  - When the URL starts with `/uploads/` or `/assets/`, keeps it.  
  - When it's an absolute URL, parses with the `URL` constructor and checks that the protocol is `https:` (never `javascript:`, `data:`, etc.), checks the allowed host, *and* path.  
  - For anything else, returns an empty string.
- Add an *explicit* protocol check for both relative and absolute URLs, always ensuring only approved protocols and hosts are allowed.
- Make sure this logic covers all code paths in `getSafeImageUrl`, and document the checks clearly for maintainers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
