### PR TITLE
Change Supabase health check to database ping endpoint

### DIFF
--- a/.github/workflows/santarita.yml
+++ b/.github/workflows/santarita.yml
@@ -12,21 +12,23 @@ jobs:
   supabase-ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Supabase Health Check
+      - name: Supabase Database Ping
         run: |
-          # GET /auth/v1/health — endpoint de health check do GoTrue, aceita anon key
-          response=$(curl -s -w "%{http_code}" \
+          # GET /rest/v1/ — PostgREST endpoint that actually queries PostgreSQL,
+          # keeping the Supabase database from pausing due to inactivity.
+          # /auth/v1/health only checks GoTrue (auth service), not the database.
+          response=$(curl -s -o /tmp/response.json -w "%{http_code}" \
                 -H "apikey: ${{ secrets.SUPABASE_SANTARITA_KEY }}" \
-                "${{ secrets.SUPABASE_SANTARITA_URL }}/auth/v1/health" \
-                -o /tmp/response.json)
+                -H "Authorization: Bearer ${{ secrets.SUPABASE_SANTARITA_KEY }}" \
+                "${{ secrets.SUPABASE_SANTARITA_URL }}/rest/v1/")
 
-          echo "Health check response: $response"
+          echo "Database ping response: $response"
 
           if [[ "$response" =~ ^2[0-9][0-9]$ ]]; then
-            echo "Supabase is healthy"
+            echo "Supabase database is active"
             cat /tmp/response.json
           else
-            echo "Supabase health check failed with status code $response"
+            echo "Supabase database ping failed with status code $response"
             cat /tmp/response.json
             exit 1
           fi


### PR DESCRIPTION
## Summary
Updated the Supabase health check workflow to query the PostgREST database endpoint instead of the GoTrue authentication service endpoint. This ensures the database remains active and prevents it from pausing due to inactivity.

## Key Changes
- Changed endpoint from `/auth/v1/health` to `/rest/v1/` to directly query PostgreSQL through PostgREST
- Added `Authorization: Bearer` header alongside the existing `apikey` header for proper authentication
- Updated curl command to capture response to `/tmp/response.json` before the HTTP status code
- Updated all user-facing messages from "health check" to "database ping" and "healthy" to "active" to reflect the actual purpose
- Added clarifying comments explaining why the PostgREST endpoint is used instead of the auth service endpoint

## Implementation Details
The change ensures that the scheduled workflow actually keeps the Supabase database active by making a real database query through PostgREST, rather than just checking the authentication service health. This prevents the database from entering a paused state due to inactivity, which is important for applications that rely on scheduled tasks.

https://claude.ai/code/session_01We4eLNobiCjGbDg3UJWu2x